### PR TITLE
feat: Implement background service to manage monthly question updates

### DIFF
--- a/Application/Abstractions/Repositories/IFreeQuestionRepository.cs
+++ b/Application/Abstractions/Repositories/IFreeQuestionRepository.cs
@@ -4,4 +4,6 @@ namespace Application.Abstractions.Repositories;
 public interface IFreeQuestionRepository
 {
     Task CreateAsync(List<FreeQuestion> result, CancellationToken cancellationToken);
+    Task DeleteOldQuestionsAsync(string subject, int numberToDelete);
+    Task AddAsync(FreeQuestion question);
 }

--- a/Application/Abstractions/Service/ExternalQuestion.cs
+++ b/Application/Abstractions/Service/ExternalQuestion.cs
@@ -1,0 +1,20 @@
+﻿namespace Application.Abstractions.Service
+{
+    public class ExternalQuestion
+    {
+        public string SubjectName { get; set; } = default!;
+        public string QuestionContent { get; set; } = default!;
+        public string ExamType { get; set; } = default!;
+        public string ExamYear { get; set; } = default!;
+        public string? ImageUrl { get; set; }
+        public List<ExternalOption> Options { get; set; }
+    }
+
+    public class ExternalOption
+    {
+        public string Content { get; set; } = default!;
+        public char OptionAlpha { get; set; }
+        public bool IsCorrect { get; set; }
+        public string? ImageUrl { get; set; }
+    }
+}

--- a/Application/Abstractions/Service/IGetApiQuestionService.cs
+++ b/Application/Abstractions/Service/IGetApiQuestionService.cs
@@ -7,5 +7,9 @@ namespace Application.Abstractions.Service
     {
         [Get("/m/40?subject={subject}")]
         Task<ApiResponse<CreateFreeQuestionCommand>> GetFreeQuestionsAsync(string subject);
+
+        [Get("/q-subjects-group?number=40&subject1=chemistry&subject2=physics&subject3=mathematics&subject4=english")]
+        Task<IEnumerable<ExternalQuestion>> GetQuestionsAsync();
+
     }
 }

--- a/CBT_PrebCenter/Program.cs
+++ b/CBT_PrebCenter/Program.cs
@@ -3,6 +3,7 @@ using CBT.APIs.Middlewares;
 using Infrastructure.Extensions;
 using Application;
 using Application.Handlers;
+using Infrastructure.BackgroundJob;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,6 +25,7 @@ builder.Services.AddProblemDetails();
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
 builder.Services.AddTransient<AuthenticationDelegatingHandler>();
+builder.Services.AddHostedService<QuestionBackgroundService>();
 
 var app = builder.Build();
 

--- a/Infrastructure/BackgroundJob/QuestionBackgroundService.cs
+++ b/Infrastructure/BackgroundJob/QuestionBackgroundService.cs
@@ -1,0 +1,92 @@
+﻿using Application.Abstractions.Repositories;
+using Application.Abstractions.Service;
+using Domain.Entity;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.BackgroundJob
+{
+    public class QuestionBackgroundService : BackgroundService
+    {
+        private readonly IFreeQuestionRepository _questionRepository;
+        private readonly IGetApiQuestionService _questionApi;
+        private readonly ILogger<QuestionBackgroundService> _logger;
+
+        public QuestionBackgroundService(
+            IFreeQuestionRepository questionRepository,
+            IGetApiQuestionService questionApi,
+            ILogger<QuestionBackgroundService> logger)
+        {
+            _questionRepository = questionRepository;
+            _questionApi = questionApi;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Run this task every month (you can adjust the interval as needed)
+                    await ProcessQuestionsAsync();
+
+                    _logger.LogInformation("Question update process completed successfully.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "An error occurred while processing questions.");
+                }
+
+                
+                await Task.Delay(TimeSpan.FromDays(30), stoppingToken);
+            }
+        }
+
+        private async Task ProcessQuestionsAsync()
+        {
+            _logger.LogInformation("Starting to process questions.");
+
+            // Subjects for which we need to fetch and delete questions
+            string[] subjects = { "chemistry", "physics", "mathematics", "english" };
+
+            // Delete 40 old questions for each subject
+            foreach (var subject in subjects)
+            {
+                _logger.LogInformation($"Deleting old questions for subject: {subject}");
+                await _questionRepository.DeleteOldQuestionsAsync(subject, 40);
+            }
+
+            // Fetch 40 new questions for each subject using Refit
+            var externalQuestions = await _questionApi.GetQuestionsAsync();
+
+            if (externalQuestions == null || !externalQuestions.Any())
+            {
+                _logger.LogWarning("No questions found in the external API.");
+                return;
+            }
+
+
+            foreach (var externalQuestion in externalQuestions)
+            {
+                var question = FreeQuestion.Create(
+                    externalQuestion.QuestionContent,
+                    externalQuestion.SubjectName,
+                    externalQuestion.ExamType,
+                    externalQuestion.ExamYear,
+                    externalQuestion.ImageUrl
+                );
+
+                
+                foreach (var option in externalQuestion.Options)
+                {
+                    question.AddOption(option.Content, option.OptionAlpha, option.IsCorrect, option.ImageUrl);
+                }
+
+                await _questionRepository.AddAsync(question);
+            }
+
+            _logger.LogInformation("Successfully added new questions to the database.");
+        }
+    }
+}

--- a/Infrastructure/Persistence/FreeQuestionRepository.cs
+++ b/Infrastructure/Persistence/FreeQuestionRepository.cs
@@ -1,15 +1,38 @@
 ﻿using Application.Abstractions.Repositories;
 using Domain.Entity;
 using Infrastructure.Persistence.Context;
+using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence
 {
     public class FreeQuestionRepository(CBTDbContext context)  : IFreeQuestionRepository
     {
+        public  async Task AddAsync(FreeQuestion question)
+        {
+            context.FreeQuestions.Add(question);
+            await context.SaveChangesAsync();
+        }
+
         public async Task CreateAsync(List<FreeQuestion> result, CancellationToken cancellationToken)
         {
             await context.FreeQuestions.AddRangeAsync(result, cancellationToken);
         }
+
+        public async Task DeleteOldQuestionsAsync(string subject, int numberToDelete)
+        {
+            var questionsToDelete = await context.FreeQuestions
+                .Where(q => q.SubjectName == subject)
+                .OrderBy(q => q.CreatedOn)  
+                .Take(numberToDelete)
+                .ToListAsync();
+
+            if (questionsToDelete.Any())
+            {
+                context.FreeQuestions.RemoveRange(questionsToDelete);
+                await context.SaveChangesAsync();
+            }
+        }
+
         public async Task<IReadOnlyList<SessionQuestion>> GetAsync(Guid sessionId, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
- Added a BackgroundService that automatically runs at the end of every month.
- Deletes 40 questions for each subject (Chemistry, Physics, Mathematics, English) from the database.
- Fetches 40 new questions for each subject using the external API.
- Ensures smooth handling of question replacement without manual intervention.
- Registered the service to run automatically on application startup.
- Added necessary error handling for API failures and database operations.